### PR TITLE
Improved Linting Standards

### DIFF
--- a/docker-local/README.md
+++ b/docker-local/README.md
@@ -13,7 +13,7 @@ Docker Compose configuration to support local testing with AWS services.
    - `db.table: kt_local`
    - `db.parallel: 2`
 3. Run the server
-   - `AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_ENDPOINT_URL=http://localhost:8000 AWS_REGION=local-kt go run github.com/signalapp/keytransparency/cmd/kt-server -config ./example/config.yaml `
+   - `AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_ENDPOINT_URL=http://localhost:8000 AWS_REGION=local-kt go run github.com/signalapp/keytransparency/cmd/kt-server -config ./example/config.yaml`
 4. Test with kt-client
 5. Stop the server
 6. Stop the container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 ARG GO_VERSION
 FROM --platform=linux/amd64 golang:${GO_VERSION}-alpine AS build
 COPY . /src
-RUN cd /src/cmd/kt-server && go build
+WORKDIR /src/cmd/kt-server
+RUN go build
 
 FROM --platform=linux/amd64 alpine:latest AS run
 COPY --from=build /src/cmd/kt-server/kt-server /bin/kt-server


### PR DESCRIPTION
Replaced `cd` with `WORKDIR`, and removed trailing space