### PR TITLE
Return last consistency proof for distinguished queries

### DIFF
--- a/cmd/kt-client/distinguished.go
+++ b/cmd/kt-client/distinguished.go
@@ -31,6 +31,11 @@ func handleDistinguished(client pb.KeyTransparencyQueryServiceClient) {
 	if *configFile == "" {
 		p.Printf("Verification skipped\n")
 	} else {
+		if *last != -1 {
+			// Verifying the consistency proof would require persistent state, which kt-client doesn't have,
+			// so we nullify these fields.
+			removeConsistencyProofsForStatelessVerification(res.TreeHead)
+		}
 		if err := transparency.VerifySearch(newStore(), createTreeSearchRequest([]byte("distinguished")), createTreeSearchResponse(res.Distinguished, res.TreeHead)); err != nil {
 			p.Printf("Verification failed: %v\n", err)
 		} else {

--- a/cmd/kt-client/search.go
+++ b/cmd/kt-client/search.go
@@ -77,8 +77,7 @@ func handleSearch(client pb.KeyTransparencyQueryServiceClient) {
 	if *last != -1 {
 		// Verifying the consistency proof would require persistent state, which kt-client doesn't have,
 		// so we nullify these fields.
-		res.TreeHead.Last = nil
-		res.TreeHead.Distinguished = nil
+		removeConsistencyProofsForStatelessVerification(res.TreeHead)
 	}
 
 	allVerificationsSuccessful := true
@@ -115,6 +114,14 @@ func createTreeSearchRequest(key []byte) *tpb.TreeSearchRequest {
 		SearchKey:   key,
 		Consistency: consistency(last),
 	}
+}
+
+func removeConsistencyProofsForStatelessVerification(treeHead *tpb.FullTreeHead) {
+	if treeHead == nil {
+		return
+	}
+	treeHead.Last = nil
+	treeHead.Distinguished = nil
 }
 
 func createTreeSearchResponse(response *pb.CondensedTreeSearchResponse, treeHead *tpb.FullTreeHead) *tpb.TreeSearchResponse {

--- a/cmd/kt-client/search_test.go
+++ b/cmd/kt-client/search_test.go
@@ -1,0 +1,71 @@
+//
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/signalapp/keytransparency/tree/transparency"
+	tpb "github.com/signalapp/keytransparency/tree/transparency/pb"
+	transparency_test "github.com/signalapp/keytransparency/tree/transparency/test"
+)
+
+func TestRemoveConsistencyProofsForStatelessVerification_AllowsStatelessSearchVerification(t *testing.T) {
+	tree, persistentStore, config, _ := transparency_test.NewTree(t, transparency.ContactMonitoring)
+
+	keys, err := transparency_test.RandomTree(tree, persistentStore, 10, []int{4}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.BatchUpdateFake(3); err != nil {
+		t.Fatal(err)
+	}
+
+	last := transparency_test.Last(persistentStore).Last
+	req := &tpb.TreeSearchRequest{
+		SearchKey: keys[0],
+		Consistency: &tpb.Consistency{
+			Last:          last,
+			Distinguished: last,
+		},
+	}
+	res, err := tree.Search(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.TreeHead.Last) == 0 {
+		t.Fatal("Expected last consistency proof")
+	}
+	if len(res.TreeHead.Distinguished) == 0 {
+		t.Fatal("Expected distinguished consistency proof")
+	}
+
+	statelessStore := &clientStorage{config: config.Public()}
+	if err := transparency.VerifySearch(statelessStore, req, res); err == nil {
+		t.Fatal("Expected stateless verification to reject returned consistency proofs")
+	} else if !strings.Contains(err.Error(), "consistency proof provided when not expected") {
+		t.Fatalf("Expected unexpected consistency proof error, got %v", err)
+	}
+
+	removeConsistencyProofsForStatelessVerification(res.TreeHead)
+
+	if res.TreeHead.Last != nil {
+		t.Fatal("Expected last consistency proof to be removed")
+	}
+	if res.TreeHead.Distinguished != nil {
+		t.Fatal("Expected distinguished consistency proof to be removed")
+	}
+
+	statelessStore = &clientStorage{config: config.Public()}
+	if err := transparency.VerifySearch(statelessStore, req, res); err != nil {
+		t.Fatalf("Expected stateless verification to pass after removing consistency proofs, got %v", err)
+	}
+}
+
+func TestRemoveConsistencyProofsForStatelessVerification_NilTreeHead(t *testing.T) {
+	removeConsistencyProofsForStatelessVerification(nil)
+}

--- a/cmd/kt-client/update.go
+++ b/cmd/kt-client/update.go
@@ -96,7 +96,7 @@ func handleUpdate(client pb.KeyTransparencyTestServiceClient) {
 		// so we nullify these fields.
 		if *last != -1 {
 			req.Consistency = nil
-			res.TreeHead.Last = nil
+			removeConsistencyProofsForStatelessVerification(res.TreeHead)
 		}
 		if err := transparency.VerifyUpdate(newStore(), req, res); err != nil {
 			p.Printf("Verification failed: %v\n", err)

--- a/cmd/kt-server/kt_query_handler.go
+++ b/cmd/kt-server/kt_query_handler.go
@@ -69,6 +69,7 @@ func (h *KtQueryHandler) distinguished(req *pb.DistinguishedRequest) (*pb.Distin
 	searchReq := &tpb.TreeSearchRequest{
 		SearchKey: []byte(distinguishedSearchKey),
 		Consistency: &tpb.Consistency{
+			Last:          req.Last,
 			Distinguished: req.Last,
 		},
 	}

--- a/cmd/kt-server/kt_query_handler_test.go
+++ b/cmd/kt-server/kt_query_handler_test.go
@@ -22,6 +22,7 @@ import (
 	commonerrors "github.com/signalapp/keytransparency/common-errors"
 	"github.com/signalapp/keytransparency/db"
 	"github.com/signalapp/keytransparency/tree"
+	logtree "github.com/signalapp/keytransparency/tree/log"
 	tpb "github.com/signalapp/keytransparency/tree/transparency/pb"
 )
 
@@ -49,6 +50,68 @@ func TestDistinguished_NilRequest(t *testing.T) {
 	if grpcError, ok := status.FromError(err); grpcError.Code() != codes.InvalidArgument || !ok {
 		t.Fatalf("Expected %v, got %v",
 			codes.InvalidArgument, err)
+	}
+}
+
+func TestDistinguished_LastReturnsConsistencyProof(t *testing.T) {
+	mockConfig, _ := config.Read(mockConfigFile)
+	mockTransparencyStore := db.NewMemoryTransparencyStore()
+	accountDb := db.MockAccountDB{}
+	h := KtQueryHandler{config: mockConfig.APIConfig, tx: mockTransparencyStore, accountDB: &accountDb}
+
+	tree, err := mockConfig.APIConfig.NewTree(mockTransparencyStore)
+	if err != nil {
+		t.Fatalf("Unexpected error creating tree, %v", err)
+	}
+
+	_, err = tree.UpdateSimple(&tpb.UpdateRequest{
+		SearchKey:   []byte(distinguishedSearchKey),
+		Value:       []byte("1"),
+		Consistency: &tpb.Consistency{},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error updating distinguished key, %v", err)
+	}
+
+	last := tree.GetTransparencyTreeHead().TreeSize
+	lastRoot, err := tree.GetLogTree().GetRoot(last)
+	if err != nil {
+		t.Fatalf("Unexpected error getting previous root, %v", err)
+	}
+
+	_, err = tree.UpdateSimple(&tpb.UpdateRequest{
+		SearchKey:   random(16),
+		Value:       []byte("2"),
+		Consistency: &tpb.Consistency{},
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error updating tree, %v", err)
+	}
+
+	resp, err := h.distinguished(&pb.DistinguishedRequest{Last: &last})
+	if err != nil {
+		t.Fatalf("Unexpected error looking up distinguished key, %v", err)
+	}
+	if resp.TreeHead == nil || resp.TreeHead.TreeHead == nil {
+		t.Fatal("Expected tree head")
+	}
+	if len(resp.TreeHead.Last) == 0 {
+		t.Fatal("Expected last consistency proof")
+	}
+	if len(resp.TreeHead.Distinguished) == 0 {
+		t.Fatal("Expected distinguished consistency proof")
+	}
+
+	current := resp.TreeHead.TreeHead.TreeSize
+	currentRoot, err := tree.GetLogTree().GetRoot(current)
+	if err != nil {
+		t.Fatalf("Unexpected error getting current root, %v", err)
+	}
+	if err := logtree.VerifyConsistencyProof(last, current, resp.TreeHead.Last, lastRoot, currentRoot); err != nil {
+		t.Fatalf("Expected valid last consistency proof, got %v", err)
+	}
+	if err := logtree.VerifyConsistencyProof(last, current, resp.TreeHead.Distinguished, lastRoot, currentRoot); err != nil {
+		t.Fatalf("Expected valid distinguished consistency proof, got %v", err)
 	}
 }
 


### PR DESCRIPTION
fixes #11

## summary
- map the distinguished request's `last` tree size into both returned consistency proof slots
- keep the existing distinguished proof behavior while also returning the missing `Last` proof
- keep kt-client stateless verification working when distinguished lookups use `-last`
- add regression coverage for the server proof response and the client-side consistency proof cleanup

## testing
- `go test ./cmd/kt-client -run TestRemoveConsistencyProofsForStatelessVerification -count=1`
- `go test ./cmd/kt-client -count=1`
- `go test ./cmd/kt-server -run TestDistinguished_LastReturnsConsistencyProof -count=1`
- `go build ./...`
- `go test -count=1 ./...`
- `(cd filter-key-updates && ./mvnw verify)`